### PR TITLE
Enables runtime to register and run classes

### DIFF
--- a/docs/function-execution.md
+++ b/docs/function-execution.md
@@ -35,6 +35,28 @@ True # returns False if registration fails, e.g., if one of the referenced funct
 * DAGs can have arbitrary branches and connections and have multiple sources, but there must be only one sink function in the DAG. The result of this sink function is what is returned to the caller.
 * For those familiar with the Anna KVS, all use of lattices is abstracted away from the Droplet user. The serialization and deserialization is done automatically by the runtime, and only Python values are passed into and out of all API functions.
 
+## Registering and Executing Classes
+
+Some functions require preinitialization that can be potentially expensive (e.g., loading a machine learning model).
+Instead of repeating this expensive initialization process on every request, users can also register a Python class with the runtime instead of a function.
+This class will be initialized as a part of a DAG<sup>1</sup>, and the initialized state will persist until the resources are deallocated.
+When registering a class, the client expects a tuple with two arguments: The first is the class itself, and the second is the set of initialization arguments.
+The class itself must have a `run` method, which will be invoked for each request.
+The example below shows the expected structure.
+
+```python3
+class Expensive:
+  def __init__(self, arg):
+    expensive_operation(arg)
+
+  def run(self, arg):
+    # ... do some work ...
+    return result 
+
+cloud.register((Expensive, init_arg), 'expensive_class')
+```
+
+<sup>1</sup> Note that the benefits of using a class will not work with one-shot function execution, as the class will be reinitialized for each request.
 
 ## Droplet User Library
 

--- a/docs/function-execution.md
+++ b/docs/function-execution.md
@@ -39,7 +39,7 @@ True # returns False if registration fails, e.g., if one of the referenced funct
 
 Some functions require preinitialization that can be potentially expensive (e.g., loading a machine learning model).
 Instead of repeating this expensive initialization process on every request, users can also register a Python class with the runtime instead of a function.
-This class will be initialized as a part of a DAG<sup>1</sup>, and the initialized state will persist until the resources are deallocated.
+When this class is initialized as part of a DAG<sup>1</sup>, the initialized state will persist until the resources are deallocated
 When registering a class, the client expects a tuple with two arguments: The first is the class itself, and the second is the set of initialization arguments.
 The class itself must have a `run` method, which will be invoked for each request.
 The example below shows the expected structure.

--- a/droplet/client/client.py
+++ b/droplet/client/client.py
@@ -119,8 +119,10 @@ class DropletConnection():
 
     def register(self, function, name):
         '''
-        Registers a new function with the system. The returned object can be
-        called like a regular Python function, which returns a Droplet Future.
+        Registers a new function or class with the system. The returned object
+        can be called like a regular Python function, which returns a Droplet
+        Future. If the input is a class, the class is expected to have a run
+        method, which is what is invoked at runtime.
 
         function: The function object that we are registering.
         name: A unique name for the function to be stored with in the system.

--- a/droplet/server/executor/utils.py
+++ b/droplet/server/executor/utils.py
@@ -52,7 +52,7 @@ def retrieve_function(name, kvs, consistency=NORMAL):
     if type(result) == tuple:
         cls = result[0]
         obj = cls(*result[1])
-        result = cls.run
+        result = obj.run
 
     return result
 

--- a/droplet/server/executor/utils.py
+++ b/droplet/server/executor/utils.py
@@ -30,7 +30,7 @@ def retrieve_function(name, kvs, consistency=NORMAL):
         # This means that the function is stored in an LWWPairLattice.
         lattice = kvs.get(kvs_name)[kvs_name]
         if lattice:
-            return serializer.load_lattice(lattice)
+            result = serializer.load_lattice(lattice)
         else:
             return None
     else:
@@ -41,9 +41,20 @@ def retrieve_function(name, kvs, consistency=NORMAL):
         if lattice:
             # If there are multiple concurrent values, we arbitrarily pick the
             # first one listed.
-            return serializer.load_lattice(lattice)[0]
+            result = serializer.load_lattice(lattice)[0]
         else:
             return None
+
+    # Check to see if the result is a tuple. This means that the first object
+    # in the tuple is a class that we can initialize, and the second value is a
+    # set of initialization args. Otherwise, we just return the retrieved
+    # function.
+    if type(result) == tuple:
+        cls = result[0]
+        obj = cls(*result[1])
+        result = cls.run
+
+    return result
 
 
 def push_status(schedulers, pusher_cache, status):


### PR DESCRIPTION
If requests are expected to persist state across invocations (e.g., load a ML model once and then invoke it multiple times), it makes sense to encapsulate that state in a class rather than recreate it every time. This PR enables that. 

The function execution [docs](docs/function-execution.md) have a more detailed explanation of the expected structure of this operation.