### PR TITLE
Fixing missing packages in setup.py.

### DIFF
--- a/scripts/install-anna.sh
+++ b/scripts/install-anna.sh
@@ -17,6 +17,6 @@
 cd $HOME
 git clone --recurse-submodules https://github.com/hydro-project/anna
 cd anna/client/python
-python setup.py install
+python3 setup.py install
 cd $HOME
 rm -rf anna


### PR DESCRIPTION
Before this patch, I was getting errors like:

```
ubuntu@ip-172-31-7-219:~/hydro-project/droplet/droplet/client$ python3 run_benchmark.py                                   
Traceback (most recent call last):                                                                                                   
  File "run_benchmark.py", line 21, in <module>                                                                                   
    from droplet.client.client import DropletConnection                                                                         
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/client/client.py", line 20, in <module>                   
    from droplet.shared.function import DropletFunction                                                                              
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/shared/function.py", line 16, in <module>          
    from droplet.shared.serializer import Serializer                                                                 
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/shared/serializer.py", line 28, in <module>                  
    from droplet.server.utils import DEFAULT_VC, generate_timestamp                                                        
ModuleNotFoundError: No module named 'droplet.server' 
```

even after running `python3 setup.py install` and the other setup scripts.