### PR TITLE
Fixing missing packages in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from distutils.core import setup
 import os
+import setuptools
+
+from distutils.core import setup
 from setuptools.command.install import install
 
 
@@ -40,7 +42,7 @@ class InstallWrapper(install):
 setup(
         name='Droplet',
         version='0.1.0',
-        packages=['droplet', ],
+        packages=setuptools.find_packages(),
         license='Apache v2',
         long_description='The Droplet Client and Server',
         install_requires=['zmq', 'protobuf', 'anna'],


### PR DESCRIPTION
Before this patch, I was getting errors like

```
ubuntu@ip-172-31-7-219:~/hydro-project/droplet/droplet/client$ python3 run_benchmark.py                                   
Traceback (most recent call last):                                                                                                   
  File "run_benchmark.py", line 21, in <module>                                                                                   
    from droplet.client.client import DropletConnection                                                                         
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/client/client.py", line 20, in <module>                   
    from droplet.shared.function import DropletFunction                                                                              
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/shared/function.py", line 16, in <module>          
    from droplet.shared.serializer import Serializer                                                                 
  File "/home/ubuntu/.local/lib/python3.6/site-packages/droplet/shared/serializer.py", line 28, in <module>                  
    from droplet.server.utils import DEFAULT_VC, generate_timestamp                                                        
ModuleNotFoundError: No module named 'droplet.server' 
```