### PR TITLE
User library key miss fix; dockerfile typo fix.

### DIFF
--- a/dockerfiles/start-droplet.sh
+++ b/dockerfiles/start-droplet.sh
@@ -83,6 +83,6 @@ elif [[ "$ROLE" = "benchmark" ]]; then
   echo "    droplet_address: $FUNCTION_ADDR" >> conf/droplet-config.yml
   echo "    thread_id: $THREAD_ID" >> conf/droplet-config.yml
 
-  python3.6 droplet/server/benchmark/server.py
+  python3.6 droplet/server/benchmarks/server.py
 fi
 

--- a/droplet/server/executor/user_library.py
+++ b/droplet/server/executor/user_library.py
@@ -75,7 +75,11 @@ class DropletUserLibrary(AbstractDropletUserLibrary):
         # Deserialize each of the lattice objects and return them to the
         # client.
         for key in kv_pairs:
-            result[key] = serializer.load_lattice(kv_pairs[key])
+            # If the key is not in the kvs, we can just return None.
+            if kv_pairs[key] is None:
+                result[key] = None
+            else:
+                result[key] = serializer.load_lattice(kv_pairs[key])
 
         if type(ref) == list:
             return result


### PR DESCRIPTION
User library fix: handling key miss for get().
Dockerfile fix: benchmark server path.