### PR TITLE
Fixes silent failure on client

### DIFF
--- a/droplet/shared/function.py
+++ b/droplet/shared/function.py
@@ -26,4 +26,7 @@ class DropletFunction():
 
     def __call__(self, *args):
         obj_id = self._conn.exec_func(self.name, args)
+        if obj_id is None or len(obj_id) == 0:
+            return None
+
         return DropletFuture(obj_id, self._kvs_client, serializer)


### PR DESCRIPTION
When the scheduler node returns an empty object ID because it was not able to find resources on which to execute the function, we were previously returning a `DropletFuture` with an empty object ID, which would in turn cause the Anna routing node to crash.

This PR returns `None` if the client does not receive an object ID to signify that the function could not be executed.